### PR TITLE
Fixed the problem with setting the column width of the whole table.

### DIFF
--- a/DocX/Table.cs
+++ b/DocX/Table.cs
@@ -274,7 +274,7 @@ namespace Novacode
             if (grid == null)
             {
                 XElement tblPr = GetOrCreate_tblPr();
-                tblPr.AddAfterSelf(XName.Get("tblGrid", DocX.w.NamespaceName));
+                tblPr.AddAfterSelf(new XElement(XName.Get("tblGrid", DocX.w.NamespaceName)));
                 grid = Xml.Element(XName.Get("tblGrid", DocX.w.NamespaceName));
             }
 

--- a/UnitTests/DocXUnitTests.cs
+++ b/UnitTests/DocXUnitTests.cs
@@ -2731,7 +2731,22 @@ namespace UnitTests
                     Assert.AreEqual(bookmarkNames[i], result[i]);
                 }
             }
-        }        
+        }
+
+        [TestMethod]
+        public void CreateTable_WhenCalledSetColumnWidth_ReturnsExpected()
+        {
+            using (var document = DocX.Create("Set column width.docx"))
+            {
+                var table = document.InsertTable(1, 2);
+
+                table.SetColumnWidth(0, 1000);
+                table.SetColumnWidth(1, 2000);
+
+                Assert.AreEqual(1000, table.GetColumnWidth(0));
+                Assert.AreEqual(2000, table.GetColumnWidth(1));                
+            }
+        }
     }
 }
        


### PR DESCRIPTION
When I tried to set the width of a column (`SetColumnWidth`) for the whole table, the `NullReferenceException` was thrown. I found the problem in this line:

` tblPr.AddAfterSelf(XName.Get("tblGrid", DocX.w.NamespaceName));`

Instead of creating the `tblGrid` element, it inserts the text into the document so in the next line 

`grid = Xml.Element(XName.Get("tblGrid", DocX.w.NamespaceName));`

it cannot find recently inserted element wich leads to the `NullReferenceException` in the next lines.

The fix is really simple:

`tblPr.AddAfterSelf(new XElement(XName.Get("tblGrid", DocX.w.NamespaceName)));`

I added the test to check the issue and to validate the solution.

Thanks for the attention and hope it helps.