### PR TITLE
Fixed the font size changing in Paragraph

### DIFF
--- a/DocX/Paragraph.cs
+++ b/DocX/Paragraph.cs
@@ -2710,16 +2710,16 @@ namespace Novacode
                 }
 
                 rPr.SetElementValue(textFormatPropName, value);
-                var last = rPr.Elements().Last();
-                if (content as System.Xml.Linq.XAttribute != null)//If content is an attribute
+                var last = rPr.Elements(textFormatPropName).Last();
+                if (content as XAttribute != null)//If content is an attribute
                 {
-                    if (last.Attribute(((System.Xml.Linq.XAttribute)(content)).Name) == null)
+                    if (last.Attribute(((XAttribute)(content)).Name) == null)
                     {
                         last.Add(content); //Add this attribute if element doesn't have it
                     }
                     else
                     {
-                        last.Attribute(((System.Xml.Linq.XAttribute)(content)).Name).Value = ((System.Xml.Linq.XAttribute)(content)).Value; //Apply value only if element already has it
+                        last.Attribute(((XAttribute)(content)).Name).Value = ((XAttribute)(content)).Value; //Apply value only if element already has it
                     }
                 }
                 return;
@@ -2745,33 +2745,33 @@ namespace Novacode
                 }
 
                 rPr.SetElementValue(textFormatPropName, value);
-                XElement last = rPr.Elements().Last();
+                XElement last = rPr.Elements(textFormatPropName).Last();
 
                 if (contentIsListOfFontProperties) //if content is a list of attributes, as in the case when specifying a font family 
                 {
                     foreach (object property in fontProps)
                     {
-                        if (last.Attribute(((System.Xml.Linq.XAttribute)(property)).Name) == null)
+                        if (last.Attribute(((XAttribute)(property)).Name) == null)
                         {
                             last.Add(property); //Add this attribute if element doesn't have it
                         }
                         else
                         {
-                            last.Attribute(((System.Xml.Linq.XAttribute)(property)).Name).Value =
-                              ((System.Xml.Linq.XAttribute)(property)).Value; //Apply value only if element already has it
+                            last.Attribute(((XAttribute)(property)).Name).Value =
+                              ((XAttribute)(property)).Value; //Apply value only if element already has it
                         }
                     }
                 }
 
-                if (content as System.Xml.Linq.XAttribute != null)//If content is an attribute
+                if (content as XAttribute != null)//If content is an attribute
                 {
-                    if (last.Attribute(((System.Xml.Linq.XAttribute)(content)).Name) == null)
+                    if (last.Attribute(((XAttribute)(content)).Name) == null)
                     {
                         last.Add(content); //Add this attribute if element doesn't have it
                     }
                     else
                     {
-                        last.Attribute(((System.Xml.Linq.XAttribute)(content)).Name).Value = ((System.Xml.Linq.XAttribute)(content)).Value; //Apply value only if element already has it
+                        last.Attribute(((XAttribute)(content)).Name).Value = ((XAttribute)(content)).Value; //Apply value only if element already has it
                     }
                 }
                 else

--- a/UnitTests/DocXUnitTests.cs
+++ b/UnitTests/DocXUnitTests.cs
@@ -2747,6 +2747,27 @@ namespace UnitTests
                 Assert.AreEqual(2000, table.GetColumnWidth(1));                
             }
         }
+
+        [TestMethod]
+        public void UpdateParagraphFontSize_WhenSetFontSize_ReturnsExpected()
+        {
+            using (var document = DocX.Create("Update paragraph font size.docx"))
+            {
+                var paragraph = document.InsertParagraph().FontSize(9);
+
+                paragraph.FontSize(11);
+
+                string szValue = paragraph.Xml.Descendants(XName.Get("sz", DocX.w.NamespaceName))
+                   .Attributes(XName.Get("val", DocX.w.NamespaceName)).First().Value;
+                string szCsValue = paragraph.Xml.Descendants(XName.Get("szCs", DocX.w.NamespaceName))
+                   .Attributes(XName.Get("val", DocX.w.NamespaceName)).First().Value;
+
+                // the expected value is multiplied by 2
+                // and the last font size is 11*2 = 22
+                Assert.AreEqual("22", szValue);
+                Assert.AreEqual("22", szCsValue);
+            }
+        }
     }
 }
        


### PR DESCRIPTION
The issue (the font size doesn't change) appears when the font size of the paragraph should be changed the second time (or many times). I found the problem and it was in this line

`var last = rPr.Elements().Last();`

The font size consist of two elements (`sz` and `szCs`) and the aforementioned method was modifying only the last one. 

The test method is also provided.

Kind regards & have a good weekend!