### PR TITLE
Migration from MSTest to NUnit

### DIFF
--- a/UnitTests/AppendBookmark.cs
+++ b/UnitTests/AppendBookmark.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using NUnit.Framework;
 using Novacode;
 using System;
 using System.Collections.Generic;
@@ -7,10 +7,10 @@ using System.Text;
 
 namespace UnitTests
 {
-    [TestClass]
+    [TestFixture]
     public class AppendBookmark
     {
-        [TestMethod]
+        [Test]
         public void Bookmark_should_be_appended()
         {
             using (var doc = DocX.Create(""))
@@ -22,7 +22,7 @@ namespace UnitTests
             }
         }
 
-        [TestMethod]
+        [Test]
         public void Bookmark_should_be_named_correctly()
         {
             using (var doc = DocX.Create(""))
@@ -34,7 +34,7 @@ namespace UnitTests
             }
         }
 
-        [TestMethod]
+        [Test]
         public void Bookmark_should_reference_paragraph()
         {
             using (var doc = DocX.Create(""))

--- a/UnitTests/InsertAtBookmark.cs
+++ b/UnitTests/InsertAtBookmark.cs
@@ -2,14 +2,14 @@
 using Novacode;
 using System.Linq;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace UnitTests
 {
-    [TestClass]
+    [TestFixture]
     public class InsertAtBookmark
     {
-        [TestMethod]
+        [Test]
         public void Inserting_at_bookmark_should_add_text_in_paragraph()
         {
             using (var document = DocX.Create(""))
@@ -25,7 +25,7 @@ namespace UnitTests
             }
         }
 
-        [TestMethod]
+        [Test]
         public void Inserting_at_bookmark_should_add_text_in_header()
         {
             using (var document = DocX.Create(""))
@@ -43,7 +43,7 @@ namespace UnitTests
             }
         }
 
-        [TestMethod]
+        [Test]
         public void Inserting_at_bookmark_should_add_text_in_footer()
         {
             using (var document = DocX.Create(""))

--- a/UnitTests/ReplaceTests.cs
+++ b/UnitTests/ReplaceTests.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Text.RegularExpressions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 using Novacode;
 
 namespace UnitTests
 {
-    [TestClass]
+    [TestFixture]
     public class RegExTest
     {
         private readonly Dictionary<string, string> _testPatterns = new Dictionary<string, string>
@@ -13,17 +14,11 @@ namespace UnitTests
             { "COURT NAME", "Fred Frump" },
             { "Case Number", "cr-md-2011-1234567" }
         };
-        private readonly TestHelper _testHelper;
 
-        public RegExTest()
-        {
-            _testHelper = new TestHelper();
-        }
-
-        [TestMethod]
+        [Test]
         public void ReplaceText_Can_ReplaceViaFunctionHandler()
         {
-            using (var replaceDoc = DocX.Load(_testHelper.DirectoryWithFiles + "ReplaceTests.docx"))
+            using (var replaceDoc = DocX.Load(Path.Combine(TestHelper.DirectoryWithFiles, "ReplaceTests.docx")))
             {
                 foreach (var t in replaceDoc.Tables)
                 {

--- a/UnitTests/TestHelper.cs
+++ b/UnitTests/TestHelper.cs
@@ -1,14 +1,17 @@
-﻿namespace UnitTests
-{
-    public class TestHelper
-    {
-        public string DirectoryWithFiles { get; }
+﻿using System;
+using System.IO;
 
-        public TestHelper()
+namespace UnitTests
+{
+    public static class TestHelper
+    {
+        static TestHelper()
         {
-            var relativeDirectory = new RelativeDirectory(); // prepares the files for testing
-            relativeDirectory.Up(3);
-            DirectoryWithFiles = relativeDirectory.Path + @"\UnitTests\documents\";
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
+            DirectoryWithFiles = Path.Combine(baseDirectory, "documents");
         }
+
+        public static string DirectoryWithFiles { get; }
     }
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -48,7 +48,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\DocX\bin\Debug\DocX.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.4.1\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
@@ -75,35 +78,85 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DocXUnitTests.cs" />
-    <Compile Include="RelativeDirectory.cs" />
     <Compile Include="ReplaceTests.cs" />
     <Compile Include="TestHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="documents\EverybodyHasAHome.docx" />
-    <None Include="documents\FontFormat.docx" />
-    <None Include="documents\Hyperlinks.docx" />
-    <None Include="documents\Images.docx" />
-    <None Include="documents\MovePicture.docx" />
-    <None Include="documents\Paragraphs.docx" />
-    <None Include="documents\ReplaceTests.docx" />
-    <None Include="documents\Tables.docx" />
-    <None Include="documents\Template.dotx" />
-    <None Include="documents\testdoc_OrderedList.docx" />
-    <None Include="documents\testdoc_OrderedUnorderedLists.docx" />
-    <None Include="documents\testdoc_SectionsWithHeadingBreaks.docx" />
-    <None Include="documents\testdoc_SectionsWithSectionBreaks.docx" />
-    <None Include="documents\testdoc_SectionsWithSectionBreaksMultiParagraph.docx" />
-    <None Include="documents\testdoc_UnorderedList.docx" />
-    <None Include="documents\TestParent.docx" />
-    <None Include="documents\VariousTextFormatting.docx" />
+    <None Include="documents\EverybodyHasAHome.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\FontFormat.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\Hyperlinks.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\Images.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\LargeTable.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\MovePicture.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\Paragraphs.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\ReplaceTests.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\Tables.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\TableSpecifiedWidths.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\Template.dotx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\testdoc_OrderedList.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\testdoc_OrderedUnorderedLists.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\testdoc_SectionsWithHeadingBreaks.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\testdoc_SectionsWithSectionBreaks.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\testdoc_SectionsWithSectionBreaksMultiParagraph.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\testdoc_UnorderedList.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\TestParent.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="documents\VariousTextFormatting.docx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="documents\green.jpg" />
-    <Content Include="documents\orange.gif" />
-    <Content Include="documents\purple.png" />
-    <Content Include="documents\red.bmp" />
-    <Content Include="documents\yellow.tif" />
+    <Content Include="documents\green.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="documents\orange.gif">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="documents\purple.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="documents\red.bmp">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="documents\yellow.tif">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.4.1" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
Migration to NUnit 3.4.1 to allow cross platform testing. Visual Studio Integration for NUnit can be downloaded [here](https://visualstudiogallery.msdn.microsoft.com/0da0f6bd-9bb6-4ae3-87a8-537788622f2d).

Notable changes are
- Replaced Microsoft.VisualStudio.TestTools.UnitTesting with NUnit.Framework
- Using AppDomain.CurrentDomain.BaseDirectory instead of Assembly.GetExecutingAssembly().Location to the determine the location of .docx files and other resources. This method is invariant under the test runner in use -- see TestHelper.
- Using Path.Combine("a", "b") to build paths of the form "a\b" or "a/b" depending on the platform.
- Resources are set to "Copy if newer" to include them during build.