### PR TITLE
Adding configurations for AppVeyor and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: csharp
+solution: DocX.sln
+install:
+  - nuget restore DocX.sln
+  - nuget install NUnit.Console -Version 3.4.1 -OutputDirectory testrunner
+script:
+  - xbuild /p:Configuration=Debug DocX.sln
+  - mono --debug ./testrunner/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe ./UnitTests/bin/Debug/UnitTests.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+before_build:
+  - nuget restore DocX.sln
+build:
+  project: DocX.sln
+  verbosity: minimal


### PR DESCRIPTION
To activate AppVeyor builds, login on https://ci.appveyor.com/ and select this repository.
To activate Travis CI builds, login on https://travis-ci.org/ and select this repository.
Both services are free of charge since this is an open source repository.

Finally, you can enable AppVeyor hooks and Travis CI service [here](https://github.com/WordDocX/DocX/settings/hooks) so that github displays the build status next to commits.