### PR TITLE
Fix for #17

### DIFF
--- a/DocX/DocX.cs
+++ b/DocX/DocX.cs
@@ -2533,40 +2533,42 @@ namespace Novacode
 
             foreach (var rel in document.mainPart.GetRelationships())
             {
+                string url = "/word/" + rel.TargetUri.OriginalString.Replace("/word/", "").Replace("file://", "");
+
                 switch (rel.RelationshipType)
                 {
                     case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes":
-                        document.endnotesPart = package.GetPart(new Uri("/word/" + rel.TargetUri.OriginalString.Replace("/word/", ""), UriKind.Relative));
+                        document.endnotesPart = package.GetPart(new Uri(url, UriKind.Relative));
                         using (TextReader tr = new StreamReader(document.endnotesPart.GetStream()))
                             document.endnotes = XDocument.Load(tr);
                         break;
 
                     case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes":
-                        document.footnotesPart = package.GetPart(new Uri("/word/" + rel.TargetUri.OriginalString.Replace("/word/", ""), UriKind.Relative));
+                        document.footnotesPart = package.GetPart(new Uri(url, UriKind.Relative));
                         using (TextReader tr = new StreamReader(document.footnotesPart.GetStream()))
                             document.footnotes = XDocument.Load(tr);
                         break;
 
                     case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles":
-                        document.stylesPart = package.GetPart(new Uri("/word/" + rel.TargetUri.OriginalString.Replace("/word/", ""), UriKind.Relative));
+                        document.stylesPart = package.GetPart(new Uri(url, UriKind.Relative));
                         using (TextReader tr = new StreamReader(document.stylesPart.GetStream()))
                             document.styles = XDocument.Load(tr);
                         break;
 
                     case "http://schemas.microsoft.com/office/2007/relationships/stylesWithEffects":
-                        document.stylesWithEffectsPart = package.GetPart(new Uri("/word/" + rel.TargetUri.OriginalString.Replace("/word/", ""), UriKind.Relative));
+                        document.stylesWithEffectsPart = package.GetPart(new Uri(url, UriKind.Relative));
                         using (TextReader tr = new StreamReader(document.stylesWithEffectsPart.GetStream()))
                             document.stylesWithEffects = XDocument.Load(tr);
                         break;
 
                     case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable":
-                        document.fontTablePart = package.GetPart(new Uri("/word/" + rel.TargetUri.OriginalString.Replace("/word/", ""), UriKind.Relative));
+                        document.fontTablePart = package.GetPart(new Uri(url, UriKind.Relative));
                         using (TextReader tr = new StreamReader(document.fontTablePart.GetStream()))
                             document.fontTable = XDocument.Load(tr);
                         break;
 
                     case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering":
-                        document.numberingPart = package.GetPart(new Uri("/word/" + rel.TargetUri.OriginalString.Replace("/word/", ""), UriKind.Relative));
+                        document.numberingPart = package.GetPart(new Uri(url, UriKind.Relative));
                         using (TextReader tr = new StreamReader(document.numberingPart.GetStream()))
                             document.numbering = XDocument.Load(tr);
                         break;


### PR DESCRIPTION
On mono, the OriginalString of a Uri sometimes is prefixed with file:// leading to issues when combining paths. We strip the prefix if necessary to avoid that.

This also fixes Saving_and_loading_a_template_should_work and Test_Table_InsertRowAndColumn failing on Travis.