### PR TITLE
Fix for failing FontFamily name test

### DIFF
--- a/UnitTests/DocXUnitTests.cs
+++ b/UnitTests/DocXUnitTests.cs
@@ -2074,9 +2074,11 @@ namespace UnitTests
             {
                 Paragraph p = document.InsertParagraph();
 
-                p.Append("Hello World").Font(new FontFamily("Symbol"));
+                var fontFamily = new FontFamily("Symbol");
 
-                Assert.AreEqual(p.MagicText[0].formatting.FontFamily.Name, "Symbol");
+                p.Append("Hello World").Font(fontFamily);
+
+                Assert.AreEqual(p.MagicText[0].formatting.FontFamily.Name, fontFamily.Name);
 
                 document.Save();
             }


### PR DESCRIPTION
On mono the actual name of a FontFamily may be different from the alias used to create the FontFamily.