### PR TITLE
Code cleanup - introducing the 'nameof' operator instead of string values

### DIFF
--- a/DocX.iOS/System/IO/Packaging/Check.cs
+++ b/DocX.iOS/System/IO/Packaging/Check.cs
@@ -66,7 +66,7 @@ namespace System.IO.Packaging
         public static void Package(object package)
         {
             if (package == null)
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
         }
 
 
@@ -78,22 +78,22 @@ namespace System.IO.Packaging
         public static void PackageUriIsValid(Uri packageUri)
         {
             if (!packageUri.IsAbsoluteUri)
-                throw new ArgumentException("packageUri", "Uri must be absolute");
+                throw new ArgumentException(nameof(packageUri), "Uri must be absolute");
         }
 
         public static void PackUriIsValid(Uri packUri)
         {
             if (!packUri.IsAbsoluteUri)
-                throw new ArgumentException("packUri", "PackUris must be absolute");
+                throw new ArgumentException(nameof(packUri), "PackUris must be absolute");
 
             if (packUri.Scheme != PackUriHelper.UriSchemePack)
-                throw new ArgumentException("packUri", "Uri scheme is not a valid PackUri scheme");
+                throw new ArgumentException(nameof(packUri), "Uri scheme is not a valid PackUri scheme");
         }
 
         public static void PartUri(object partUri)
         {
             if (partUri == null)
-                throw new ArgumentNullException("partUri");
+                throw new ArgumentNullException(nameof(partUri));
         }
 
         public static void PartUriIsValid(Uri partUri)
@@ -108,7 +108,7 @@ namespace System.IO.Packaging
         public static void RelationshipTypeIsValid(string relationshipType)
         {
             if (relationshipType == null)
-                throw new ArgumentNullException("relationshipType");
+                throw new ArgumentNullException(nameof(relationshipType));
             if (EmptyOrBlank(relationshipType))
                 throw new ArgumentException("relationshipType", "Cannot be whitespace or empty");
         }
@@ -116,11 +116,11 @@ namespace System.IO.Packaging
         public static void PartUri(Uri partUri)
         {
             if (partUri == null)
-                throw new ArgumentNullException("partUri");
+                throw new ArgumentNullException(nameof(partUri));
             if (partUri.IsAbsoluteUri)
-                throw new ArgumentException("partUri", "Absolute URIs are not supported");
+                throw new ArgumentException(nameof(partUri), "Absolute URIs are not supported");
             if (string.IsNullOrEmpty(partUri.OriginalString))
-                throw new ArgumentException("partUri", "Part uri cannot be an empty string");
+                throw new ArgumentException(nameof(partUri), "Part uri cannot be an empty string");
         }
 
         public static void PackUri(Uri packUri)
@@ -143,21 +143,21 @@ namespace System.IO.Packaging
         public static void SourceUri(Uri sourceUri)
         {
             if (sourceUri == null)
-                throw new ArgumentNullException("sourceUri");
+                throw new ArgumentNullException(nameof(sourceUri));
             //			if (sourceUri.IsAbsoluteUri)
             //				throw new ArgumentException ("sourceUri", "Absolute URIs are not supported");
             if (string.IsNullOrEmpty(sourceUri.OriginalString))
-                throw new ArgumentException("sourceUri", "Part uri cannot be an empty string");
+                throw new ArgumentException(nameof(sourceUri), "Part uri cannot be an empty string");
         }
 
         public static void TargetUri(Uri targetUri)
         {
             if (targetUri == null)
-                throw new ArgumentNullException("targetUri");
+                throw new ArgumentNullException(nameof(targetUri));
             //			if (targetUri.IsAbsoluteUri)
             //				throw new ArgumentException ("targetUri", "Absolute URIs are not supported");
             if (string.IsNullOrEmpty(targetUri.OriginalString))
-                throw new ArgumentException("targetUri", "Part uri cannot be an empty string");
+                throw new ArgumentException(nameof(targetUri), "Part uri cannot be an empty string");
         }
     }
 }

--- a/DocX/Charts/XElementHelpers.cs
+++ b/DocX/Charts/XElementHelpers.cs
@@ -14,7 +14,7 @@ namespace Novacode
         internal static T GetValueToEnum<T>(XElement element)
         {
             if (element == null)
-                throw new ArgumentNullException("element");
+                throw new ArgumentNullException(nameof(element));
 
             String value = element.Attribute(XName.Get("val")).Value;
             foreach (T e in Enum.GetValues(typeof(T)))
@@ -36,7 +36,7 @@ namespace Novacode
         internal static void SetValueFromEnum<T>(XElement element, T value)
         {
             if (element == null)
-                throw new ArgumentNullException("element");
+                throw new ArgumentNullException(nameof(element));
             element.Attribute(XName.Get("val")).Value = GetXmlNameFromEnum<T>(value);
         }
 
@@ -47,7 +47,7 @@ namespace Novacode
         internal static String GetXmlNameFromEnum<T>(T value)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
 
             FieldInfo fi = typeof(T).GetField(value.ToString());
             if (fi.GetCustomAttributes(typeof(XmlNameAttribute), false).Count() == 0)

--- a/DocX/ExtensionsHeadings.cs
+++ b/DocX/ExtensionsHeadings.cs
@@ -51,7 +51,7 @@ namespace Novacode
                 return false;
 
             if (value == null)
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
 
             // Not as good as the .NET 4 version of this function, but should be good enough
             if (!Enum.IsDefined(variable.GetType(), value))

--- a/DocX/Paragraph.cs
+++ b/DocX/Paragraph.cs
@@ -4619,7 +4619,7 @@ namespace Novacode
         internal static XElement[] SplitText(Text t, int index)
         {
             if (index < t.startIndex || index > t.EndIndex)
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
 
             XElement splitLeft = null, splitRight = null;
             if (t.Xml.Name.LocalName == "t" || t.Xml.Name.LocalName == "delText")

--- a/DocX/Table.cs
+++ b/DocX/Table.cs
@@ -1475,7 +1475,7 @@ namespace Novacode
         public Row InsertRow(Row row, int index)
         {
             if (row == null)
-                throw new ArgumentNullException("row");
+                throw new ArgumentNullException(nameof(row));
 
             if (index < 0 || index > RowCount)
                 throw new IndexOutOfRangeException();


### PR DESCRIPTION
- Simple replacement for basic scenarios like throwing an exception
- No logic code change