### PR TITLE
Update Container.cs

### DIFF
--- a/DocX/Container.cs
+++ b/DocX/Container.cs
@@ -278,9 +278,9 @@ namespace Novacode
             List<Paragraph> paragraphs = new List<Paragraph>();
             foreach (XElement e in Xml.Descendants(XName.Get("p", DocX.w.NamespaceName)))
             {
-                index += HelperFunctions.GetText(e).Length;
                 Paragraph paragraph = new Paragraph(Document, e, index);
                 paragraphs.Add(paragraph);
+                index += HelperFunctions.GetText(e).Length;
             }
             //  GetParagraphsRecursive(Xml, ref index, ref paragraphs, deepSearch);
 
@@ -435,7 +435,7 @@ namespace Novacode
                 List<int> indexes = p.FindAll(str, options);
 
                 for (int i = 0; i < indexes.Count(); i++)
-                    indexes[0] += p.startIndex;
+                    indexes[i] += p.startIndex;
 
                 list.AddRange(indexes);
             }


### PR DESCRIPTION
The paragraph startindex and endindex are corrupted in Document.paragraphs[].
The result was a wrong insertion of paragraphs and tables. (at wrong locations)
The function GetParagraphs had the bug. the variable index in that function should be updated after creation of the paragraph not before

The function public virtual List<int> FindAll(string str, RegexOptions options) was only resulting one item in the list. instead of a list of find idexes 
If there was only find one no big problem but if it finds more the return index was wrong also .
I think  it is a  typo error, instead of  indexes[0]  it should be indexes[i].