### PR TITLE
Update HelperFunctions.cs

### DIFF
--- a/DocX/HelperFunctions.cs
+++ b/DocX/HelperFunctions.cs
@@ -524,13 +524,13 @@ namespace Novacode
         internal static Paragraph GetFirstParagraphEffectedByInsert(DocX document, int index)
         {
             // This document contains no Paragraphs and insertion is at index 0
-            if (document.paragraphLookup.Keys.Count() == 0 && index == 0)
+            if (document.Paragraphs.Count() == 0 && index == 0)
                 return null;
 
-            foreach (int paragraphEndIndex in document.paragraphLookup.Keys)
+            foreach (Paragraph p in document.Paragraphs)
             {
-                if (paragraphEndIndex >= index)
-                    return document.paragraphLookup[paragraphEndIndex];
+                if (p.endIndex >= index)
+                    return p;
             }
 
             throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
On my search to solve the inserting problem of tables and paragraphs I change this code.
If the document.paragraphLookup is always correct or filled no problem.
But why depend on document.paragraphLookup if it can be done direct?
So this is not a bug.
For me it is not clear why we have the dictionary paragraphLookup.
Is there a real need for the dictionary paragraphLookup, or is it just a result of historical starting ideas and should it be cleaned?