### PR TITLE
Optimization to AddImage

### DIFF
--- a/DocX/DocX.csproj
+++ b/DocX/DocX.csproj
@@ -53,7 +53,7 @@
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>
@@ -63,6 +63,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/DocX/Header.cs
+++ b/DocX/Header.cs
@@ -149,7 +149,7 @@ namespace Novacode
         {
             get
             {
-                PackageRelationshipCollection imageRelationships = mainPart.GetRelationshipsByType("http://schemas.openxmlformats.org/officeDocument/2006/relationships/image");
+                PackageRelationshipCollection imageRelationships = mainPart.GetRelationshipsByType(DocX.relationshipImage);
                 if (imageRelationships.Count() > 0)
                 {
                     return

--- a/DocX/HelperFunctions.cs
+++ b/DocX/HelperFunctions.cs
@@ -47,7 +47,7 @@ namespace Novacode
         }
         internal static void CreateRelsPackagePart(DocX Document, Uri uri)
         {
-            PackagePart pp = Document.package.CreatePart(uri, "application/vnd.openxmlformats-package.relationships+xml", CompressionOption.Maximum);
+            PackagePart pp = Document.package.CreatePart(uri, DocX.contentTypeApplicationRelationShipXml, CompressionOption.Maximum);
             using (TextWriter tw = new StreamWriter(new PackagePartStream(pp.GetStream())))
             {
                 XDocument d = new XDocument

--- a/DocX/PackagePartStream.cs
+++ b/DocX/PackagePartStream.cs
@@ -1,14 +1,14 @@
 ﻿using System.IO;
-using System.Threading;
 
 namespace Novacode
 {
     /// <summary>
-    /// See <a href="https://support.microsoft.com/en-gb/kb/951731" /> for explanation
+    /// OpenXML Isolated Storage access is not thread safe.
+    /// Use app domain wide lock for writing.
     /// </summary>
     public class PackagePartStream : Stream
     {
-        private static readonly Mutex Mutex = new Mutex(false);
+        private static readonly object lockObject = new object();
 
         private readonly Stream stream;
 
@@ -60,16 +60,18 @@ namespace Novacode
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            Mutex.WaitOne(Timeout.Infinite, false);
-            this.stream.Write(buffer, offset, count);
-            Mutex.ReleaseMutex();
+            lock (lockObject)
+            {
+                this.stream.Write(buffer, offset, count);
+            }
         }
 
         public override void Flush()
         {
-            Mutex.WaitOne(Timeout.Infinite, false);
-            this.stream.Flush();
-            Mutex.ReleaseMutex();
+            lock (lockObject)
+            {
+                this.stream.Flush();
+            }
         }
 
         public override void Close()

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -48,9 +48,6 @@
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DocX">
-      <HintPath>..\DocX\bin\Debug\DocX.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -77,7 +74,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\DocX\DocX.csproj">
+      <Project>{e863d072-aa8b-4108-b5f1-785241b37f67}</Project>
+      <Name>DocX</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -46,10 +46,6 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DocX, Version=1.0.0.21, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\DocX\bin\Debug\DocX.dll</HintPath>
-    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\nunit.framework.2.63.0\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
@@ -164,6 +160,12 @@
     <Content Include="documents\yellow.tif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DocX\DocX.csproj">
+      <Project>{e863d072-aa8b-4108-b5f1-785241b37f67}</Project>
+      <Name>DocX</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
We encountered some performance problems when using DocX and adding a big amount of images. Our test case had ~800 images added to document and it took 280 seconds in our benchmark test case and CPU usage was high. 

After profiling and analysis we found that AddImage did quite expensive operations and they got more expensive as amount of images were growing. There were nested loops which made the performance O(n^2).

I have done the changes listed below and after the changes our generation took 24 seconds, the document otherwise stayed the same. I'm opening this pull request to offer these changes and to discuss whether you would be open to accept them.

* minimize closure allocations by replacing LINQ with foreach when needed
* use lookups when possible
* reuse filtered items, pre-compute when possible
* use lighter Monitor for isolated storage locking instead of Mutex
* fix DocX references to be real project references instead of DLL references
* tweaks to reduce code/key duplication
* allow optional content type when loading data from stream