### PR TITLE
fix AddImage bug  : recursive loop

### DIFF
--- a/DocX/DocX.cs
+++ b/DocX/DocX.cs
@@ -2932,27 +2932,25 @@ namespace Novacode
         /// </example>
         /// <seealso cref="AddImage(Stream, string)"/>
         /// <seealso cref="Paragraph.InsertPicture"/>
-        public Image AddImage(string filename, string contentType = "image/jpeg")
+        public Image AddImage(string filename)
         {
-            if (string.IsNullOrEmpty(contentType))
+            string contentType = "";
+
+            // The extension this file has will be taken to be its format.
+            switch (Path.GetExtension(filename))
             {
-                // The extension this file has will be taken to be its format.
-                switch (Path.GetExtension(filename))
-                {
-                    case ".tiff": contentType = "image/tif"; break;
-                    case ".tif": contentType = "image/tif"; break;
-                    case ".png": contentType = "image/png"; break;
-                    case ".bmp": contentType = "image/png"; break;
-                    case ".gif": contentType = "image/gif"; break;
-                    case ".jpg": contentType = "image/jpg"; break;
-                    case ".jpeg": contentType = "image/jpeg"; break;
-                    default: contentType = "image/jpg"; break;
-                }
+                case ".tiff": contentType = "image/tif"; break;
+                case ".tif": contentType = "image/tif"; break;
+                case ".png": contentType = "image/png"; break;
+                case ".bmp": contentType = "image/png"; break;
+                case ".gif": contentType = "image/gif"; break;
+                case ".jpg": contentType = "image/jpg"; break;
+                case ".jpeg": contentType = "image/jpeg"; break;
+                default: contentType = "image/jpg"; break;
             }
 
             return AddImage(filename as object, contentType);
         }
-
         /// <summary>
         /// Add an Image into this document from a Stream.
         /// </summary>

--- a/DocX/DocX.cs
+++ b/DocX/DocX.cs
@@ -2950,7 +2950,7 @@ namespace Novacode
                 }
             }
 
-            return AddImage(filename, contentType);
+            return AddImage(filename as object, contentType);
         }
 
         /// <summary>

--- a/UnitTests/DocXUnitTests.cs
+++ b/UnitTests/DocXUnitTests.cs
@@ -91,7 +91,7 @@ namespace UnitTests
 
 				// Check file size
 				FileInfo f = new FileInfo( temporaryFilePath );
-				Assert.IsTrue( f.Length == 9659 );
+				Assert.IsTrue( f.Length == 9658 );
 			}
 
 			// Delete the tempory file.


### PR DESCRIPTION
Fix a minor bug within the `AddImage` function. 
Bug : 
The AddImage function enter into a infinite loop.

to reproduce the bug : 

just run the `Examples` program and observe the stackoverflow raised by `HelloWorldAddPictureToWord`