### PR TITLE
Add Support For EastAsia FontFamily In Formatting

### DIFF
--- a/DocX/Formatting.cs
+++ b/DocX/Formatting.cs
@@ -193,7 +193,8 @@ namespace Novacode
                             XName.Get("rFonts", DocX.w.NamespaceName), 
                             new XAttribute(XName.Get("ascii", DocX.w.NamespaceName), fontFamily.Name),
                             new XAttribute(XName.Get("hAnsi", DocX.w.NamespaceName), fontFamily.Name), // Added by Maurits Elbers to support non-standard characters. See http://docx.codeplex.com/Thread/View.aspx?ThreadId=70097&ANCHOR#Post453865
-                            new XAttribute(XName.Get("cs", DocX.w.NamespaceName), fontFamily.Name)    // Added by Maurits Elbers to support non-standard characters. See http://docx.codeplex.com/Thread/View.aspx?ThreadId=70097&ANCHOR#Post453865
+                            new XAttribute(XName.Get("cs", DocX.w.NamespaceName), fontFamily.Name),    // Added by Maurits Elbers to support non-standard characters. See http://docx.codeplex.com/Thread/View.aspx?ThreadId=70097&ANCHOR#Post453865
+			    new XAttribute(XName.Get("eastAsia", DocX.w.NamespaceName), fontFamily.Name)	// DOCX in china #57
                         )
                     );
                 }


### PR DESCRIPTION
看到在段落的设置中添加了对中文字体的支持，但是在文字的样式中并没有，在此同样添加对中文字体的支持。